### PR TITLE
59 bug select dropdown toggle

### DIFF
--- a/src/components/input/Select/Select.test.tsx
+++ b/src/components/input/Select/Select.test.tsx
@@ -143,7 +143,6 @@ describe('SearchSelect', () => {
 
       userEvent.keyboard('{esc}');
       expect(dropDownContainer).not.toBeInTheDocument();
-      expect(inputELem).not.toHaveFocus();
     });
 
     test('should close on click outside of select', () => {
@@ -713,7 +712,7 @@ describe('SearchSelect', () => {
     expect(within(dropDownContainer).queryAllByTestId('option').length).toBe(0);
     expect(within(dropDownContainer).getByText('Нет совпадений')).toBeInTheDocument();
   });
-  test('blur is called ones while select is active', () => {
+  test('blur is called only when click outside component', () => {
     const onBlur = jest.fn();
     render(<SelectComponent onBlur={onBlur} />);
 
@@ -721,6 +720,7 @@ describe('SearchSelect', () => {
     userEvent.keyboard('{enter}');
     userEvent.keyboard('on');
     userEvent.keyboard('{esc}');
+    userEvent.tab();
 
     expect(onBlur).toBeCalledTimes(1);
   });

--- a/src/components/input/Select/index.tsx
+++ b/src/components/input/Select/index.tsx
@@ -396,10 +396,6 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
       }
     };
 
-    const onWrapperClick = () => {
-      setIsSearchPanelOpen(true);
-    };
-
     const extendSelectValueToInputValue = () => {
       if (!visibleValueIsString || searchValue || !shouldRenderSelectValue) return;
 
@@ -436,11 +432,8 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
 
     const onBlur = (evt: React.FocusEvent<HTMLDivElement>) => {
       setIsFocused(false);
-
-      if (!evt.currentTarget.contains(evt.relatedTarget)) {
-        onBlurFromProps?.(evt);
-        onCloseSelect();
-      }
+      onBlurFromProps?.(evt);
+      onCloseSelect();
     };
 
     const onChange = (evt: React.ChangeEvent<HTMLSelectElement>) => {
@@ -450,6 +443,11 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
         );
       }
       props.onChange?.(evt);
+    };
+
+    const onWrapperContentClick = (e: React.MouseEvent<any>) => {
+      stopPropagation(e);
+      handleSearchPanelToggle();
     };
 
     React.useEffect(() => {
@@ -463,8 +461,6 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     React.useEffect(() => {
       if (isSearchPanelOpen) {
         modeIsSelect ? selectRef.current?.focus() : inputRef.current?.focus();
-      } else {
-        modeIsSelect ? selectRef.current?.blur() : inputRef.current?.blur();
       }
     }, [isSearchPanelOpen, modeIsSelect]);
 
@@ -488,7 +484,8 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
         data-status={status}
         onKeyUp={handleKeyUp}
         onKeyDown={onWrapperKeyDown}
-        onClick={onWrapperClick}
+        onClick={onWrapperContentClick}
+        onMouseDown={preventDefault}
         onBlur={onBlur}
         onFocus={onFocus}
       >
@@ -524,6 +521,8 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
           multiple={multiple}
           fixHeight={shouldFixHeight}
           isEmpty={isEmpty}
+          onClick={onWrapperContentClick}
+          onMouseDown={preventDefault}
         >
           {shouldRenderSelectValue && wrappedVisibleValue}
           <Input

--- a/src/components/input/Select/index.tsx
+++ b/src/components/input/Select/index.tsx
@@ -431,9 +431,12 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     };
 
     const onBlur = (evt: React.FocusEvent<HTMLDivElement>) => {
-      setIsFocused(false);
-      onBlurFromProps?.(evt);
-      onCloseSelect();
+      // если фокус переходит не на инпут, содержащийся внутри компонента
+      if (!evt.currentTarget.contains(evt.relatedTarget)) {
+        setIsFocused(false);
+        onBlurFromProps?.(evt);
+        onCloseSelect();
+      }
     };
 
     const onChange = (evt: React.ChangeEvent<HTMLSelectElement>) => {
@@ -443,11 +446,6 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
         );
       }
       props.onChange?.(evt);
-    };
-
-    const onWrapperContentClick = (e: React.MouseEvent<any>) => {
-      stopPropagation(e);
-      handleSearchPanelToggle();
     };
 
     React.useEffect(() => {
@@ -484,7 +482,7 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
         data-status={status}
         onKeyUp={handleKeyUp}
         onKeyDown={onWrapperKeyDown}
-        onClick={onWrapperContentClick}
+        onClick={handleSearchPanelToggle}
         onMouseDown={preventDefault}
         onBlur={onBlur}
         onFocus={onFocus}
@@ -521,7 +519,6 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
           multiple={multiple}
           fixHeight={shouldFixHeight}
           isEmpty={isEmpty}
-          onClick={onWrapperContentClick}
           onMouseDown={preventDefault}
         >
           {shouldRenderSelectValue && wrappedVisibleValue}
@@ -544,6 +541,7 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
             data-dimension={dimension || TextInput.defaultProps?.dimension}
             // Запретит перенос фокуса с инпута при клике по всему, что внутри Dropdown
             onMouseDown={preventDefault}
+            onClick={stopPropagation}
             ref={dropDownRef}
           >
             <DropDownSelectProvider


### PR DESCRIPTION
1) Исправила логику открытия дропдауна: При клике на любом месте поля (кроме иконки крестика) открывается меню выбора и, если mode="searchSelect", активируется поле ввода текста. Меню закрывается при повторном клике в поле, либо при клике вне компонента, либо при выборе опции в меню.

2) Исправила логику срабатывания onBlur. Компонент теряет фокус только при клике вне него. Компонент не теряет фокус после выбора значения или закрытия дропдауна.

Все изменения согласованы с дизайнером.