### PR TITLE
Feature/custom-title

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -15,6 +15,7 @@ import {
   columnListOrientation,
   columnListSort,
   columnListSticky,
+  columnListWithCustomTitle,
   columnListWithWidth,
   rowList,
   rowListExpanded,
@@ -763,3 +764,10 @@ Group.parameters = {
     },
   },
 };
+
+export const CustomTitle = Template.bind({});
+CustomTitle.args = {
+  rowList,
+  columnList: columnListWithCustomTitle,
+};
+CustomTitle.storyName = 'Table. Пример кастомизации заголовков столбцов.';

--- a/src/components/Table/data.tsx
+++ b/src/components/Table/data.tsx
@@ -9,6 +9,7 @@ import { RowAction, RowActionProps } from '#src/components/Table';
 import type { Column } from '../Table';
 import { Tooltip } from '#src/components/Tooltip';
 import { TooltipHoc } from '#src/components/TooltipHOC';
+import { Badge } from '../Badge';
 
 const AmountCell = styled.div`
   text-overflow: ellipsis;
@@ -943,5 +944,36 @@ export const virtualColumnList: Column[] = [
     name: 'transfer_date',
     title: 'Дата сделки',
     width: '40%',
+  },
+];
+
+export const columnListWithCustomTitle: Column[] = [
+  {
+    name: 'transfer_type',
+    title: (
+      <>
+        Тип сделки <Badge>5</Badge>
+      </>
+    ),
+    width: '20%',
+  },
+  {
+    name: 'transfer_date',
+    title: <b>Дата сделки</b>,
+    width: '250px',
+  },
+  {
+    name: 'transfer_amount',
+    title: <span style={{ color: 'red', fontWeight: 'bold' }}>Сумма</span>,
+    width: 200,
+  },
+  {
+    name: 'currency',
+    title: <i>Валюта</i>,
+    extraText: <b>доллары</b>,
+  },
+  {
+    name: 'rate',
+    title: 'Ставка',
   },
 ];

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -67,7 +67,7 @@ export type Column = {
   /** Уникальное название столбца */
   name: string;
   /** Заголовок столбца */
-  title: string;
+  title: React.ReactNode | React.ReactText;
   /** Дополнительный текст заголовка столбца */
   extraText?: string;
   /** Ширина столбца. По умолчанию 100px */

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -67,9 +67,9 @@ export type Column = {
   /** Уникальное название столбца */
   name: string;
   /** Заголовок столбца */
-  title: React.ReactNode | React.ReactText;
+  title: React.ReactNode;
   /** Дополнительный текст заголовка столбца */
-  extraText?: string;
+  extraText?: React.ReactNode;
   /** Ширина столбца. По умолчанию 100px */
   width?: number | string;
   /** Выравнивание контента ячеек столбца по левому или правому краю. По умолчанию left */


### PR DESCRIPTION
Добавлена возможность рендеринга кастомного компонента в заголовок таблицы. Есть случаи когда в заголовок столбца нужно отрендерить какие то данные по столбцу 

Пример: 
![image](https://user-images.githubusercontent.com/43415209/192170920-8e53c32b-9f87-410a-8328-6a283c2e6ad3.png)
