### PR TITLE
📎 добавил id в input для select-field

### DIFF
--- a/src/components/input/Select/index.tsx
+++ b/src/components/input/Select/index.tsx
@@ -142,6 +142,7 @@ export interface SelectProps extends Omit<React.InputHTMLAttributes<HTMLSelectEl
 export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   (
     {
+      id,
       value,
       isLoading,
       className,
@@ -548,6 +549,7 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
           {shouldRenderSelectValue && wrappedVisibleValue}
           {((placeholder && isEmpty) || !modeIsSelect) && (
             <Input
+              id={id}
               placeholder={isEmpty ? placeholder : ''}
               tabIndex={-1}
               ref={inputRef}


### PR DESCRIPTION
Добавил id в input внутри select-field таким образом, что лейбл в филде теперь ссылается на инпут. Кажется это семантически верно, и поможет в тестировании компонента, так как у testing-library есть подходящий для этого метод [bylabeltext](https://testing-library.com/docs/queries/bylabeltext)

<img width="1027" alt="Снимок экрана 2022-12-12 в 11 39 49" src="https://user-images.githubusercontent.com/3207851/207012008-a6d0e414-c080-4837-8eb8-85674d0b838e.png">
