### PR TITLE
Bugfix: Исправление проблем виртуальных групп в таблице

### DIFF
--- a/src/components/Table/VirtualBody.tsx
+++ b/src/components/Table/VirtualBody.tsx
@@ -14,14 +14,13 @@ interface VirtualBodyProps extends React.HTMLAttributes<HTMLDivElement> {
   childHeight: number;
   renderAhread?: number;
   rowList: any[];
-  renderRow: (row: any, index: number) => void;
+  renderRow: (row: any, index: number) => React.ReactNode;
 }
 
 export const VirtualBody = React.forwardRef<HTMLDivElement, VirtualBodyProps>(
   ({ height, childHeight, renderAhread = 20, rowList, renderRow, ...props }, ref) => {
     const [scrollTop, setScrollTop] = React.useState(0);
     const scrollContainerRef = React.useRef<HTMLDivElement>(null);
-    const itemCount = rowList.length;
 
     const handleScroll = (e: any) => {
       requestAnimationFrame(() => {
@@ -40,6 +39,12 @@ export const VirtualBody = React.forwardRef<HTMLDivElement, VirtualBodyProps>(
     let startNode = Math.floor(scrollTop / childHeight) - renderAhread;
     startNode = Math.max(0, startNode);
 
+    const rowNodes = React.useMemo(
+      () => rowList.map((row, index) => renderRow(row, index)).filter(Boolean),
+      [rowList, renderRow],
+    );
+    const itemCount = rowNodes.length;
+
     let visibleNodeCount = Math.ceil(height / childHeight) + 2 * renderAhread;
     visibleNodeCount = Math.min(itemCount - startNode, visibleNodeCount);
 
@@ -47,8 +52,8 @@ export const VirtualBody = React.forwardRef<HTMLDivElement, VirtualBodyProps>(
     const bottomPadding = `${(itemCount - startNode - visibleNodeCount) * childHeight}px`;
 
     const visibleChildren = React.useMemo(
-      () => [...rowList].slice(startNode, startNode + visibleNodeCount).map((row, index) => renderRow(row, index)),
-      [startNode, visibleNodeCount, renderRow],
+      () => [...rowNodes].slice(startNode, startNode + visibleNodeCount),
+      [rowNodes, startNode, visibleNodeCount],
     );
 
     return (

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -620,7 +620,9 @@ export const Table: React.FC<TableProps> = ({
     const indeterminate =
       row.groupRows?.some((rowId) => rowToGroupMap[rowId].checked) &&
       row.groupRows?.some((rowId) => !rowToGroupMap[rowId].checked);
-    const checked = row.groupRows?.every((rowId) => rowToGroupMap[rowId].checked);
+
+    const hasGroupRows = row.groupRows?.length;
+    const checked = hasGroupRows ? row.groupRows?.every((rowId) => rowToGroupMap[rowId].checked) : row.selected;
 
     return (
       <GroupRow


### PR DESCRIPTION
Демо проблемы: [https://kirillkirpa.github.io/?path=/story/issues-table--virtual-groups](https://kirillkirpa.github.io/?path=/story/issues-table--virtual-groups)

При работе с группами в таблице продемонстрировано две проблемы. 
1. Когда группы находятся в закрытом состоянии, не верно рассчитывается virtual scroll (В примере должно быть 15 групп, а отрисовывается только часть).
2. Когда у группы нет дочерних строк, флаг checkbox всегда проставлен (Хочется контролировать этот процесс. К примеру когда мы выбираем "выбрать все" "снять все выделение")