### PR TITLE
fix(Select): fix non-adaptive selected long option to fit with surrounding container

### DIFF
--- a/src/components/form/FieldSet/index.tsx
+++ b/src/components/form/FieldSet/index.tsx
@@ -33,7 +33,7 @@ const FieldSetExtrasContainer = styled.div`
   margin: 0;
 `;
 
-const FieldSetContainer = styled.fieldset<{
+const FieldSetContainer = styled.div<{
   dimension?: FieldSetDimension;
   flexDirection?: 'column' | 'row';
 }>`
@@ -51,6 +51,10 @@ const FieldSetContainer = styled.fieldset<{
 
   ${Legend} {
     margin-top: 0;
+  }
+
+  & > * {
+    width: 100%;
   }
 `;
 


### PR DESCRIPTION
На данный момент, если выбранный Option в селекте больше по длине, чем сам селект (имеется ввиду, текстовая строка), то выглядит это так:

![1](https://user-images.githubusercontent.com/6165014/214235542-590219f7-08c1-4151-9387-3cffe78081f1.png)

То есть селект не обрезает строку, как ожидается по логике вещей.
А вот так выглядит после фикса:

![2](https://user-images.githubusercontent.com/6165014/214235515-01231881-4919-4336-bd81-41469af43313.png)