### PR TITLE
fix(Table): showRowsActions overflowMenu backdrop

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -29,7 +29,6 @@ import {
   NormalWrapper,
   TableContainer,
   HiddenHeader,
-  ActionBG,
   DragCell,
 } from './style';
 import { VirtualBody } from './VirtualBody';
@@ -635,7 +634,6 @@ export const Table = React.forwardRef<HTMLDivElement, TableProps>(
             </NormalWrapper>
             <Filler />
           </Header>
-          {showRowsActions && <ActionBG data-overflowmenu $dimension={dimension} $greyHeader={greyHeader} />}
         </HeaderWrapper>
         {renderBody()}
         <ColumnDrag

--- a/src/components/Table/style.ts
+++ b/src/components/Table/style.ts
@@ -56,17 +56,6 @@ export const NormalWrapper = styled.div`
   display: flex;
 `;
 
-export const ActionBG = styled.div<{
-  $dimension: TableProps['dimension'];
-  $greyHeader?: boolean;
-}>`
-  ${actionsBGStyle};
-  right: 0;
-  bottom: 1px;
-  background: ${({ theme, $greyHeader }) =>
-    $greyHeader ? theme.color['Neutral/Neutral 05'] : theme.color['Neutral/Neutral 00']};
-`;
-
 export const OverflowMenuWrapper = styled.div<{
   $offset: number;
   $dimension: TableProps['dimension'];
@@ -114,9 +103,6 @@ export const HeaderWrapper = styled.div<{ $scrollbar: number; $greyHeader?: bool
     }
     & > div.tr {
       overflow-y: scroll;
-    }
-    & > [data-overflowmenu='true'] {
-      margin-right: ${({ $scrollbar }) => $scrollbar}px;
     }
   }
 


### PR DESCRIPTION
При showRowsActions равным true, в заголовке таблицы, над иконками действий, перекрытие подложкой не происходит