### PR TITLE
feat(select) - preselected options

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -61,7 +61,7 @@ export const MenuItem = React.forwardRef<HTMLDivElement, MenuItemProps>(
       disabled,
       readOnly,
       hovered,
-      dimension = 'l',
+      dimension = 'l' as ItemDimension,
       selected = false,
       preselected = false,
       selfRef,

--- a/src/components/input/Select/NativeControl.tsx
+++ b/src/components/input/Select/NativeControl.tsx
@@ -47,7 +47,7 @@ export const NativeControl = forwardRef<HTMLSelectElement, NativeSelectProps>(
       <NativeSelect ref={refSetter(ref, selectRef)} {...props} onClick={stopPropagation}>
         <option value="" />
         {options.map((option) => (
-          <option key={option.value} value={option.value}>
+          <option key={option.value} value={option.value} disabled={option.disabled}>
             {option.value}
           </option>
         ))}


### PR DESCRIPTION
Для режима select изменена логика работы с клавиатуры - при навигации по меню клавишами «Вверх», «Вниз» или через быстрый поиск по первой букве, соответствующий пункт подсвечивается отдельным цветом. При нажатии клавиши «Enter» такой пункт является более приоритетным по отношению к пункту в состоянии «Hover».

Исправлена ошибка выбора опций в состоянии disable с клавиатуры

#1190