### PR TITLE
fix(Breadcrumbs): #1589 исправлен баг с неправильным margin, в случае…

### DIFF
--- a/src/components/Breadcrumbs/style.ts
+++ b/src/components/Breadcrumbs/style.ts
@@ -83,6 +83,7 @@ export const OverflowContent = styled.ol`
   & > li {
     margin-left: 4px;
   }
+  & > li[data-number='0'],
   & > li:last-child {
     margin-left: 0;
   }


### PR DESCRIPTION
… когда в компонент передана только одна крошка