### PR TITLE
feat: add propsConfig for some components

### DIFF
--- a/src/components/Range/index.tsx
+++ b/src/components/Range/index.tsx
@@ -5,6 +5,7 @@ import { throttle } from '#src/components/common/utils/throttle';
 import type { NumberRange } from './utils';
 import { sortNum, calcValue, calcSliderCoords, arraysEqual } from './utils';
 import { DefaultTrack, FilledTrack, Thumb, ThumbCircle, Track, TrackWrapper, Wrapper } from './style';
+import type { DataAttributes } from 'styled-components';
 
 export interface RangeProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   /** Значение компонента */
@@ -27,7 +28,21 @@ export interface RangeProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onChan
   dimension?: 'm' | 's';
   /** Состояние skeleton */
   skeleton?: boolean;
+
+  /** Конфиг функция пропсов для первого ползунка. На вход получает начальный набор пропсов, на
+   * выход должна отдавать объект с пропсами, которые будут внедряться после оригинальных пропсов. */
+  firstThumbCirclePropsConfig?: (
+    props: React.ComponentProps<typeof ThumbCircle>,
+  ) => Partial<React.ComponentProps<typeof ThumbCircle>> & DataAttributes;
+
+  /** Конфиг функция пропсов для первого ползунка. На вход получает начальный набор пропсов, на
+   * выход должна отдавать объект с пропсами, которые будут внедряться после оригинальных пропсов. */
+  secondThumbCirclePropsConfig?: (
+    props: React.ComponentProps<typeof ThumbCircle>,
+  ) => Partial<React.ComponentProps<typeof ThumbCircle>> & DataAttributes;
 }
+
+const nothing = () => ({});
 
 export const Range = ({
   minValue = 0,
@@ -39,6 +54,8 @@ export const Range = ({
   step = 1,
   dimension = 'm',
   skeleton = false,
+  firstThumbCirclePropsConfig = nothing,
+  secondThumbCirclePropsConfig = nothing,
   ...props
 }: RangeProps) => {
   const value: NumberRange =
@@ -205,6 +222,36 @@ export const Range = ({
     }
   };
 
+  const firstThumbCircleProps = {
+    $dimension: dimension,
+    onTouchStart: (e: React.TouchEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      props.onTouchStart?.(e);
+      onSliderClick(e, 'first');
+    },
+    onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      props.onMouseDown?.(e);
+      onSliderClick(e, 'first');
+    },
+    $active: isDraging,
+  };
+
+  const secondThumbCircleProps = {
+    $dimension: dimension,
+    onTouchStart: (e: React.TouchEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      props.onTouchStart?.(e);
+      onSliderClick(e, 'second');
+    },
+    onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      props.onMouseDown?.(e);
+      onSliderClick(e, 'second');
+    },
+    $active: isDraging2,
+  };
+
   return (
     <Wrapper data-disabled={disabled} $disabled={disabled} $skeleton={skeleton} {...props}>
       <TrackWrapper $dimension={dimension} $skeleton={skeleton} onTouchStart={onTrackClick} onMouseDown={onTrackClick}>
@@ -212,36 +259,10 @@ export const Range = ({
           <FilledTrack ref={filledRef} $animation={animation} />
           <DefaultTrack ref={trackRef}>
             <Thumb ref={sliderRef} $animation={animation} $dimension={dimension}>
-              <ThumbCircle
-                $dimension={dimension}
-                onTouchStart={(e) => {
-                  e.stopPropagation();
-                  props.onTouchStart?.(e);
-                  onSliderClick(e, 'first');
-                }}
-                onMouseDown={(e) => {
-                  e.stopPropagation();
-                  props.onMouseDown?.(e);
-                  onSliderClick(e, 'first');
-                }}
-                $active={isDraging}
-              />
+              <ThumbCircle {...firstThumbCircleProps} {...firstThumbCirclePropsConfig(firstThumbCircleProps)} />
             </Thumb>
             <Thumb ref={slider2Ref} $animation={animation} $dimension={dimension}>
-              <ThumbCircle
-                $dimension={dimension}
-                onTouchStart={(e) => {
-                  e.stopPropagation();
-                  props.onTouchStart?.(e);
-                  onSliderClick(e, 'second');
-                }}
-                onMouseDown={(e) => {
-                  e.stopPropagation();
-                  props.onMouseDown?.(e);
-                  onSliderClick(e, 'second');
-                }}
-                $active={isDraging2}
-              />
+              <ThumbCircle {...secondThumbCircleProps} {...secondThumbCirclePropsConfig(secondThumbCircleProps)} />
             </Thumb>
           </DefaultTrack>
         </Track>

--- a/src/components/input/InputLine/index.tsx
+++ b/src/components/input/InputLine/index.tsx
@@ -78,6 +78,7 @@ export interface InputLineProps extends React.InputHTMLAttributes<HTMLInputEleme
   value?: string;
   prefix?: string;
   suffix?: string;
+
   /** Конфиг функция пропсов для контейнера. На вход получает начальный набор пропсов, на
    * выход должна отдавать объект с пропсами, которые будут внедряться после оригинальных пропсов. */
   containerPropsConfig?: (

--- a/src/components/input/PhoneNumberInput/index.tsx
+++ b/src/components/input/PhoneNumberInput/index.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css, type DataAttributes } from 'styled-components';
 
 import { changeInputData } from '#src/components/common/dom/changeInputData';
 import { refSetter } from '#src/components/common/utils/refSetter';
@@ -109,6 +109,18 @@ export interface PhoneNumberInputProps
   defaultCountry?: CountryAlpha3Code;
   /** Список стран для выпадающего списка. Отмечается кодом ISO A3 страны */
   onlyCountries?: Array<CountryAlpha3Code>;
+
+  /** Конфиг функция пропсов для контейнера, в котором находится инпут. На вход получает начальный набор пропсов, на
+   * выход должна отдавать объект с пропсами, которые будут внедряться после оригинальных пропсов. */
+  containerPhonePropsConfig?: (
+    props: React.ComponentProps<typeof PhoneContainer>,
+  ) => Partial<React.ComponentProps<typeof PhoneContainer>> & DataAttributes;
+
+  /** Конфиг функция пропсов для кнопки выбора страны. На вход получает начальный набор пропсов, на
+   * выход должна отдавать объект с пропсами, которые будут внедряться после оригинальных пропсов. */
+  selectorCountryPropsConfig?: (
+    props: React.ComponentProps<typeof PhoneContainer>,
+  ) => Partial<React.ComponentProps<typeof PhoneContainer>> & DataAttributes;
 }
 
 const AVAILABLE_ALPHA3_CODES = Object.keys(ComponentsNames);
@@ -126,6 +138,8 @@ export const PhoneNumberInput = forwardRef<HTMLInputElement, PhoneNumberInputPro
       dropContainerCssMixin,
       dropContainerClassName,
       dropContainerStyle,
+      containerPhonePropsConfig = () => {},
+      selectorCountryPropsConfig = () => {},
       ...props
     },
     ref,
@@ -320,8 +334,24 @@ export const PhoneNumberInput = forwardRef<HTMLInputElement, PhoneNumberInputPro
       props.onFocus?.(e);
     };
 
+    const containerPhoneProps = {
+      ref: containerRef,
+      $dimension: dimension,
+      disabled,
+      readOnly: props.readOnly,
+    };
+
+    const selectorCountryProps = {
+      $skeleton: skeleton,
+      $dimension: dimension,
+      $isOpened: isOpened,
+      disabled,
+      $isLoading: props.isLoading,
+      onClick: props.isLoading ? undefined : handleButtonClick,
+    };
+
     return (
-      <PhoneContainer ref={containerRef} $dimension={dimension} disabled={disabled} readOnly={props.readOnly}>
+      <PhoneContainer {...containerPhoneProps} {...containerPhonePropsConfig(containerPhoneProps)}>
         <TextInput
           {...props}
           type="tel"
@@ -361,14 +391,7 @@ export const PhoneNumberInput = forwardRef<HTMLInputElement, PhoneNumberInputPro
             </PhoneInputDropContainer>
           )}
         </TextInput>
-        <CountryContainer
-          $skeleton={skeleton}
-          $dimension={dimension}
-          $isOpened={isOpened}
-          disabled={disabled}
-          $isLoading={props.isLoading}
-          onClick={props.isLoading ? undefined : handleButtonClick}
-        >
+        <CountryContainer {...selectorCountryProps} {...selectorCountryPropsConfig(selectorCountryProps)}>
           <FlagContainer $dimension={dimension}>{IconComponent}</FlagContainer>
           {!props.readOnly && <Chevron disabled={disabled} />}
         </CountryContainer>

--- a/src/components/input/SliderInput/index.tsx
+++ b/src/components/input/SliderInput/index.tsx
@@ -48,7 +48,15 @@ const Input = styled(NumberInput)`
 // TODO: in next major version rename onChange to OLD_onChange deprecated method,
 // and create new native input onChange with event
 
-export interface SliderInputProps extends Omit<TextInputProps, 'onChange' | 'isLoading'> {
+export interface SliderInputProps
+  extends Omit<
+    TextInputProps,
+    | 'onChange'
+    | 'isLoading'
+    | 'containerPropsConfig'
+    | 'clearInputIconButtonPropsConfig'
+    | 'visiblePasswordInputIconButtonPropsConfig'
+  > {
   /** Колбек на изменение значения компонента
    * (fullStr - строка вместе с префиксом/суффиксом/разделителями,
    * shortStr - строка только с числом без символа разделителя тысяч)
@@ -82,6 +90,14 @@ export interface SliderInputProps extends Omit<TextInputProps, 'onChange' | 'isL
   placeholder?: string;
   /** Стандартные html-атрибуты, которые будут переданы wrapper-контейнеру компонента */
   wrapperProps?: React.HTMLAttributes<HTMLDivElement>;
+
+  /** Конфиг функция пропсов для полосы в которой находится ползунок. На вход получает начальный набор пропсов, на
+   * выход должна отдавать объект с пропсами, которые будут внедряться после оригинальных пропсов. */
+  thumbPropsConfig?: React.ComponentProps<typeof Slider>['thumbPropsConfig'];
+
+  /** Конфиг функция пропсов для ползунка. На вход получает начальный набор пропсов, на
+   * выход должна отдавать объект с пропсами, которые будут внедряться после оригинальных пропсов. */
+  thumbCirclePropsConfig?: React.ComponentProps<typeof Slider>['thumbPropsConfig'];
 }
 
 export const SliderInput = forwardRef<HTMLInputElement, SliderInputProps>(
@@ -105,6 +121,8 @@ export const SliderInput = forwardRef<HTMLInputElement, SliderInputProps>(
       disabled,
       wrapperProps,
       skeleton = false,
+      thumbPropsConfig,
+      thumbCirclePropsConfig,
       ...props
     },
     ref,
@@ -203,6 +221,8 @@ export const SliderInput = forwardRef<HTMLInputElement, SliderInputProps>(
             step={step}
             disabled={disabled || props.readOnly}
             dimension={sliderDimension}
+            thumbPropsConfig={thumbPropsConfig}
+            thumbCirclePropsConfig={thumbCirclePropsConfig}
           />
         )}
       </Wrapper>

--- a/src/components/input/SliderRange/index.tsx
+++ b/src/components/input/SliderRange/index.tsx
@@ -80,6 +80,14 @@ export interface SliderRangeProps
   skeleton?: boolean;
   /** Режим readOnly компонента */
   readOnly?: boolean;
+
+  /** Конфиг функция пропсов для первого ползунка. На вход получает начальный набор пропсов, на
+   * выход должна отдавать объект с пропсами, которые будут внедряться после оригинальных пропсов. */
+  firstThumbCirclePropsConfig?: React.ComponentProps<typeof Range>['firstThumbCirclePropsConfig'];
+
+  /** Конфиг функция пропсов для первого ползунка. На вход получает начальный набор пропсов, на
+   * выход должна отдавать объект с пропсами, которые будут внедряться после оригинальных пропсов. */
+  secondThumbCirclePropsConfig?: React.ComponentProps<typeof Range>['secondThumbCirclePropsConfig'];
 }
 
 export const SliderRange: React.FC<SliderRangeProps> = ({

--- a/src/components/input/SuggestInput/index.tsx
+++ b/src/components/input/SuggestInput/index.tsx
@@ -1,6 +1,6 @@
 import type { FunctionComponent, MouseEventHandler, KeyboardEvent, ReactNode, RefObject, SVGProps } from 'react';
 import { forwardRef, useEffect, useReducer, useRef, useState, useMemo, Children } from 'react';
-import styled, { useTheme } from 'styled-components';
+import styled, { useTheme, type DataAttributes } from 'styled-components';
 
 import { ReactComponent as SearchOutlineSVG } from '@admiral-ds/icons/build/system/SearchOutline.svg';
 import { LIGHT_THEME } from '#src/components/themes';
@@ -86,6 +86,12 @@ export interface SuggestInputProps
     /** Текст сообщения при отсутствии вариантов для подстановки */
     emptyMessage?: ReactNode;
   };
+
+  /** Конфиг функция пропсов для кнопки "Поиск". На вход получает начальный набор пропсов, на
+   * выход должна отдавать объект с пропсами, которые будут внедряться после оригинальных пропсов. */
+  inputIconButtonPropsConfig?: (
+    props: React.ComponentProps<typeof InputIconButton>,
+  ) => Partial<React.ComponentProps<typeof InputIconButton>> & DataAttributes;
 }
 
 export const SuggestInput = forwardRef<HTMLInputElement, SuggestInputProps>(
@@ -112,6 +118,7 @@ export const SuggestInput = forwardRef<HTMLInputElement, SuggestInputProps>(
       dimension = 'm',
       portalTargetRef,
       targetElement,
+      inputIconButtonPropsConfig = () => {},
       ...props
     },
     ref,
@@ -187,7 +194,11 @@ export const SuggestInput = forwardRef<HTMLInputElement, SuggestInputProps>(
     const iconArray = Children.toArray(iconsAfter || icons);
 
     if (!props.readOnly) {
-      iconArray.push(<InputIconButton icon={icon} onClick={onSearchButtonClick} aria-hidden />);
+      const inputIconButtonProps = { icon: icon, onClick: onSearchButtonClick, 'aria-hidden': true };
+
+      iconArray.push(
+        <InputIconButton {...inputIconButtonProps} {...inputIconButtonPropsConfig(inputIconButtonProps)} />,
+      );
     }
 
     const emptyAtLoading: boolean = (options || []).length === 0 && !!isLoading;

--- a/src/components/input/TimePicker/index.tsx
+++ b/src/components/input/TimePicker/index.tsx
@@ -170,7 +170,17 @@ const IconPanelAfter = styled(IconPanel)`
   gap: 8px;
 `;
 
-export interface TimePickerProps extends Omit<TextInputProps, 'value' | 'iconsBefore' | 'icons'>, DropContainerStyles {
+export interface TimePickerProps
+  extends Omit<
+      TextInputProps,
+      | 'value'
+      | 'iconsBefore'
+      | 'icons'
+      | 'containerPropsConfig'
+      | 'clearInputIconButtonPropsConfig'
+      | 'visiblePasswordInputIconButtonPropsConfig'
+    >,
+    DropContainerStyles {
   /** Выбранное значение времени */
   value?: string;
   /** Начало временного диапазона */


### PR DESCRIPTION
* TextInput:
1) containerPropsConfig
2) clearInputIconButtonPropsConfig
3) visiblePasswordInputIconButtonPropsConfig

* FileItem:
1) closeButtonProps
2) containerIconProps

* SuggestInput
1) inputIconButtonPropsConfig

* PhoneNumberInput
1) containerPhonePropsConfig
2) selectorCountryPropsConfig

* InputEx
 1) clearInputIconButtonPropsConfig
 2) containerPropsConfig
 3) пропсы для вложенных компонентов dropDown через customOptionRender

* TimeInput
1) Расширил интерфейс SlotProps и теперь можно добавлять в slots={customSlots} дата атрибуты
2) timeInputIconButtonPropsConfig

* SliderInput
1) thumbPropsConfig
2) thumbCirclePropsConfig

* SliderRange
1) firstThumbCirclePropsConfig
2) secondThumbCirclePropsConfig

* NumberInput
1) containerPropsConfig
2) clearInputIconButtonPropsConfig
3) plusInputIconButtonPropsConfig
4) minusInputIconButtonPropsConfig