### PR TITLE
fix(TabMenu): не пересоздавать наблюдатели при неизменной видимости вкладок

### DIFF
--- a/src/components/TabMenu/TabMenu.test.tsx
+++ b/src/components/TabMenu/TabMenu.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 
 import { LIGHT_THEME } from '#src/components/themes';
@@ -151,5 +151,47 @@ describe('TabMenu', () => {
     const wrapper = render(<Component activeTab="1" onChange={onChange} tabs={tabs} />);
     fireEvent.click(wrapper.getByTestId('1'));
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+  // test #4
+  it('should not re-create observers when tabs visibility has not changed', () => {
+    const observe = jest.fn();
+    let notify: ((entries: unknown[]) => void) | undefined;
+    const originalIntersectionObserver = window.IntersectionObserver;
+
+    Object.defineProperty(window, 'IntersectionObserver', {
+      writable: true,
+      configurable: true,
+      value: class {
+        constructor(callback: (entries: unknown[]) => void) {
+          notify = callback;
+        }
+        observe = observe;
+        disconnect = jest.fn();
+        unobserve = jest.fn();
+      },
+    });
+
+    try {
+      render(<Component activeTab="1" onChange={jest.fn()} tabs={tabs} />);
+
+      const entries = tabs.map((_, index) => {
+        const target = document.createElement('button');
+        target.dataset.number = String(index);
+
+        return { target, isIntersecting: true, intersectionRatio: 1 };
+      });
+
+      act(() => notify?.(entries));
+      const observeCallsCount = observe.mock.calls.length;
+      act(() => notify?.(entries));
+
+      expect(observe.mock.calls.length).toBe(observeCallsCount);
+    } finally {
+      Object.defineProperty(window, 'IntersectionObserver', {
+        writable: true,
+        configurable: true,
+        value: originalIntersectionObserver,
+      });
+    }
   });
 });

--- a/src/components/TabMenu/index.tsx
+++ b/src/components/TabMenu/index.tsx
@@ -261,10 +261,11 @@ export const TabMenu: FC<TabMenuProps> = ({
         }
       });
 
-      setVisibilityMap((prev: { [index: number | string]: boolean }) => ({
-        ...prev,
-        ...updatedEntries,
-      }));
+      setVisibilityMap((prev: { [index: number | string]: boolean }) => {
+        const hasChanges = Object.keys(updatedEntries).some((key) => prev[key] !== updatedEntries[key]);
+
+        return hasChanges ? { ...prev, ...updatedEntries } : prev;
+      });
     };
     const observer = new IntersectionObserver(handleIntersection, {
       root: tablistRef.current,


### PR DESCRIPTION
## Проблема

`TabMenu` уходит в бесконечный цикл ререндеров на полностью статичной странице: ~120 коммитов React в секунду, главный поток занят скриптом непрерывно, вкладка браузера ест десятки процентов CPU. Ни DOM-мутаций, ни изменений размеров при этом нет — работа крутится вхолостую.

Воспроизводится на любой странице с `TabMenu` без каких-либо действий пользователя. Версия 8.64.0, на 8.67.0 код тот же.

## Механизм

```
observe() → IntersectionObserver отдаёт первое наблюдение
          → handleIntersection → setVisibilityMap(новый объект)
          → ререндер (bail-out невозможен, ссылка другая)
          → изменилась зависимость visibilityMap
          → useLayoutEffect пересоздаёт наблюдатель
          → observe() → …
```

`handleIntersection` возвращает новый объект **всегда**, даже когда видимость вкладок не изменилась:

```tsx
setVisibilityMap((prev) => ({ ...prev, ...updatedEntries }));
```

А `visibilityMap` стоит в зависимостях обоих `useLayoutEffect` — и того, что создаёт `IntersectionObserver` (строка 275), и того, что создаёт `ResizeObserver` с `debounce(setUnderline, 100)` (строка 249). Поэтому каждый коммит пересоздаёт оба наблюдателя и заводит два таймера.

Подчёркивание при этом не двигается: `setUnderline` выходит по проверке `activeTabLeft !== left || activeTabWidth !== underlineWidth`. Снаружи цикл незаметен — виден только по CPU.

## Решение

Обновлять состояние только при реальном изменении видимости:

```tsx
setVisibilityMap((prev) => {
  const hasChanges = Object.keys(updatedEntries).some((key) => prev[key] !== updatedEntries[key]);

  return hasChanges ? { ...prev, ...updatedEntries } : prev;
});
```

Тогда React делает bail-out, `visibilityMap` сохраняет ссылку, эффекты не перезапускаются и цикл рвётся.

Правка минимальная и намеренно не трогает списки зависимостей: `visibilityMap` в них по-прежнему нужен, чтобы пересчитать подчёркивание при действительном изменении набора видимых вкладок.

## Тест

Добавлен регресс-тест в `TabMenu.test.tsx`. Штатный мок `IntersectionObserver` в этом файле — заглушка, которая никогда не вызывает колбэк, поэтому цикл существующими тестами не ловился. В новом тесте мок сохраняет колбэк, вызывает его дважды с одинаковыми данными и проверяет, что `observe()` не вызывается заново.

Проверено, что тест падает без правки и проходит с ней.

## Проверки

- `npx jest src/components/TabMenu` — 4 passed
- `npm run typecheck` — чисто
- `npx eslint src/components/TabMenu` — без новых замечаний (единственное предупреждение на `mobile && …scrollIntoView(…)` было и до правки)
- `npx prettier --check` по изменённым файлам — чисто

Closes #2183
